### PR TITLE
Add visibility flag to remove listing from napari hub

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,0 +1,1 @@
+visibility: hidden


### PR DESCRIPTION
include visibility flag, this would hide the plugin from napari hub home page, but still allows access on the plugin page with the correct URL